### PR TITLE
Add field_meta, field_hierarchy, and field_children to the set of tables copied from staging to production on DAG run

### DIFF
--- a/new_fields_of_study_dag.py
+++ b/new_fields_of_study_dag.py
@@ -263,7 +263,8 @@ with DAG("new_fields_of_study",
     # copy to production, populate table descriptions, backup tables
     with open(f"{DAGS_DIR}/schemas/{production_dataset}/tables.json") as f:
         table_desc = json.loads(f.read())
-    for table in ["field_scores", "top_fields"]:
+    for table in ["field_scores", "top_fields", "field_meta", "field_hierarchy",
+                  "field_children"]:
         prod_table_name = f"{production_dataset}.{table}"
         table_copy = BigQueryToBigQueryOperator(
             task_id=f"copy_{table}_to_production",


### PR DESCRIPTION
The field_meta and field_children tables are largely static. They can be updated by making changes in the JSONL files in assets/fields and running upload.sh, which loads them into staging. The field_hierarchy table, then, is written from a DAG query using these metadata tables. All three need to be copied into the production dataset for it to be consistent.