### PR TITLE
Fix asset versions; simplify

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "assets/scientific-lit-embeddings"]
-	path = assets/scientific-lit-embeddings
-	url = https://github.com/georgetown-cset/scientific-lit-embeddings.git
 [submodule "dataloader"]
 	path = dataloader
 	url = https://github.com/georgetown-cset/dataloader.git

--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -10,3 +10,6 @@
 /zh_field_tfidf_vectors.json
 /zh_fasttext.bin
 /en_field_keys.txt
+/en_merged_model_120221.bin
+/id2word_dict_en_merged_sample.txt
+/tfidf_model_en_merged_sample.pkl

--- a/assets/en_merged_model_120221.bin.dvc
+++ b/assets/en_merged_model_120221.bin.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: a0c1af738c478a8eecb6cc443c50eea6
+  size: 4274901799
+  path: en_merged_model_120221.bin

--- a/assets/id2word_dict_en_merged_sample.txt.dvc
+++ b/assets/id2word_dict_en_merged_sample.txt.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: b37060c70d6b29afa3eb6d0267828147
+  size: 44493606
+  path: id2word_dict_en_merged_sample.txt

--- a/assets/tfidf_model_en_merged_sample.pkl.dvc
+++ b/assets/tfidf_model_en_merged_sample.pkl.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 37e05e681b5e67f121918018ca3efbc0
+  size: 199171820
+  path: tfidf_model_en_merged_sample.pkl

--- a/copy_assets_to_gcs.sh
+++ b/copy_assets_to_gcs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+BUCKET="gs://fields-of-study"
+
+# Files directly under the assets directory
+gcloud storage cp --no-clobber -v "assets/*" $BUCKET/assets/
+gcloud storage cp --no-clobber -v "assets/fields/" $BUCKET/assets/fields/

--- a/fos/settings.py
+++ b/fos/settings.py
@@ -6,14 +6,13 @@ FOS_DIR = Path(__file__).parent
 PIPELINES_DIR = FOS_DIR.parent
 ASSETS_DIR = PIPELINES_DIR / 'assets'
 CORPUS_DIR = ASSETS_DIR / 'corpus'
-EMBEDDINGS_DIR = ASSETS_DIR / 'scientific-lit-embeddings'
 SQL_DIR = PIPELINES_DIR / 'sql'
 
 QUERY_PATH = SQL_DIR / 'corpus.sql'
 
-EN_FASTTEXT_PATH = EMBEDDINGS_DIR / 'english/fasttext/en_merged_model_120221.bin'
-EN_TFIDF_PATH = EMBEDDINGS_DIR / 'english/tfidfs/tfidf_model_en_merged_sample.pkl'
-EN_DICT_PATH = EMBEDDINGS_DIR / 'english/tfidfs/id2word_dict_en_merged_sample.txt'
+EN_FASTTEXT_PATH = ASSETS_DIR / 'en_merged_model_120221.bin'
+EN_TFIDF_PATH = ASSETS_DIR / 'tfidf_model_en_merged_sample.pkl'
+EN_DICT_PATH = ASSETS_DIR / 'id2word_dict_en_merged_sample.txt'
 
 EN_ENTITY_PATH = ASSETS_DIR / 'en_entity_trie.pkl'
 

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -16,6 +16,14 @@ rm ~/miniconda3/miniconda.sh
 source ~/miniconda3/bin/activate
 conda init --all
 
+# Definitely accept any TOS (https://github.com/georgetown-cset/fields-of-study-pipeline/issues/67)
+# https://www.anaconda.com/docs/getting-started/tos-plugin#solution
+conda config --set plugins.auto_accept_tos yes
+# https://www.anaconda.com/docs/getting-started/tos-plugin#managing-tos-for-all-channels
+conda tos accept
+# https://www.anaconda.com/docs/getting-started/tos-plugin#installing-conda-anaconda-tos
+conda install -y --name base conda-anaconda-tos
+
 conda create -n fos python=3.8 -y
 conda activate fos
 

--- a/tests/test_fasttext.py
+++ b/tests/test_fasttext.py
@@ -4,7 +4,7 @@ import numpy as np
 from fasttext.FastText import _FastText, load_model
 
 from fos.model import FieldModel
-from fos.settings import EN_FASTTEXT_PATH, EN_FIELD_TEXT
+from fos.settings import EN_FASTTEXT_PATH
 from fos.vectors import load_fasttext, norm, embed_fasttext
 
 


### PR DESCRIPTION
This PR:
- Simplifies paths for assets by moving the models we use during the pipeline from their original submodule directly under the `assets` directory.
- Removes that submodule.
- Updates DVC to match, but also makes a copy of the current assets on GCS.